### PR TITLE
Adds EPSG:28992 Tiling Scheme.

### DIFF
--- a/projection.cpp
+++ b/projection.cpp
@@ -11,6 +11,7 @@ void (*decode_index)(unsigned long long index, unsigned *wx, unsigned *wy) = NUL
 struct projection projections[] = {
 	{"EPSG:4326", lonlat2tile, tile2lonlat, "urn:ogc:def:crs:OGC:1.3:CRS84"},
 	{"EPSG:3857", epsg3857totile, tiletoepsg3857, "urn:ogc:def:crs:EPSG::3857"},
+    {"EPSG:28992", epsg28992totile, tiletoepsg28992, "urn:ogc:def:crs:EPSG::28992"},
 	{NULL, NULL, NULL, NULL},
 };
 
@@ -99,6 +100,28 @@ void tiletoepsg3857(long long ix, long long iy, int zoom, double *ox, double *oy
 
 	*ox = (ix - (1LL << 31)) * M_PI * 6378137.0 / (1LL << 31);
 	*oy = ((1LL << 32) - 1 - iy - (1LL << 31)) * M_PI * 6378137.0 / (1LL << 31);
+}
+
+void epsg28992totile(double ix, double iy, int zoom, long long *x, long long *y) {
+    // these tiles adhere to the epsg28992 tiling scheme
+    // extent (in epgs28992) = { minx = -285401.920, miny = 22598.080, maxx = 595401.920, maxy = 903401.920 }
+    // resolution at zoom level 0: 3440.640
+    // width and heigth: 256 pixels
+
+    double resolution = 880803.84 / (1LL << zoom);
+    *x = (ix + 285401.920) / resolution;
+    *y = (903401.920 - iy) / resolution;
+}
+
+void tiletoepsg28992(long long ix, long long iy, int zoom, double *ox, double *oy) {
+    // these tiles adhere to the epsg28992 tiling scheme
+    // extent (in epgs28992) = { minx = -285401.920, miny = 22598.080, maxx = 595401.920, maxy = 903401.920 }
+    // resolution at zoom level 0: 3440.640
+    // width and heigth: 256 pixels
+
+    double resolution = 880803.84 / (1LL << zoom);
+    *ox = ix * resolution - 285401.920;
+    *oy = 903401.920 + iy * resolution;
 }
 
 // https://en.wikipedia.org/wiki/Hilbert_curve

--- a/projection.cpp
+++ b/projection.cpp
@@ -119,7 +119,7 @@ void tiletoepsg28992(long long ix, long long iy, int zoom, double *ox, double *o
     // resolution at zoom level 0: 3440.640
     // width and heigth: 256 pixels
 
-    double resolution = 880803.84 / (1LL << zoom);
+    double resolution = 880803.84 * (1LL << zoom);
     *ox = ix * resolution - 285401.920;
     *oy = 903401.920 + iy * resolution;
 }

--- a/projection.hpp
+++ b/projection.hpp
@@ -6,6 +6,8 @@ void epsg3857totile(double ix, double iy, int zoom, long long *x, long long *y);
 void tile2lonlat(long long x, long long y, int zoom, double *lon, double *lat);
 void tiletoepsg3857(long long x, long long y, int zoom, double *ox, double *oy);
 void set_projection_or_exit(const char *optarg);
+void epsg28992totile(double ix, double iy, int zoom, long long *x, long long *y);
+void tiletoepsg28992(long long x, long long y, int zoom, double *ox, double *oy);
 
 struct projection {
 	const char *name;


### PR DESCRIPTION
This adds an EPSG:28992. It is kind of broken in the sense that it does not create a valid metadata.json. Furthermore, I would propose a full implementation of a custom tiling scheme instead of this only-EPSG:28992 implementation.

So this is a trial for a fuller implementation.